### PR TITLE
支持手动刷新Token

### DIFF
--- a/examples/wxopen/authorizer_token_cache.go
+++ b/examples/wxopen/authorizer_token_cache.go
@@ -76,9 +76,9 @@ func NewAuthorizerTokenCache(
 	return &AuthorizerTokenCache{
 		accessToken: utils.NewAccessTokenCache(&authorizerAccessTokenAdaptor{
 			componentAppid: componentAppid, appid: appid,
-		}, cache, locker, 300),
+		}, cache, locker),
 		refreshToken: utils.NewAccessTokenCache(&authorizerRefreshTokenAdaptor{
 			componentAppid: componentAppid, appid: appid,
-		}, cache, locker, 300),
+		}, cache, locker),
 	}
 }

--- a/examples/wxopen/main.go
+++ b/examples/wxopen/main.go
@@ -127,10 +127,6 @@ func main() {
 		test.WxOpenOAAppid,
 		GetAuthorizerAccessToken(wxopen, oaTokenCache, test.WxOpenOAAppid),
 	)
-	// 刷新Token, 如果第一次运行， 可能会失败， 因为没有wxopen主动推送的ticket
-	if err = wxopenOA.RefreshAccessToken(); err != nil {
-		fmt.Printf("refresh oa token fail %s", err.Error())
-	}
 
 	// server
 	serverApi := server_api.NewApi(
@@ -166,6 +162,10 @@ func main() {
 	http.HandleFunc("/auth", auth(wxopen, false))
 	http.HandleFunc("/auth/mobile", auth(wxopen, true))
 	http.HandleFunc("/auth/callback", callback(wxopen, manager))
+
+	// 刷新Token
+	go RefreshWxOpenToken(wxopen)
+	go RefreshAuthorizerToken([]*authorizer.Authorizer{wxopenOA})
 
 	err = http.ListenAndServe(":5001", nil)
 	if err != nil {

--- a/examples/wxopen/token_refresh.go
+++ b/examples/wxopen/token_refresh.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/lixinio/weixin/weixin/authorizer"
+	"github.com/lixinio/weixin/wxopen"
+)
+
+func RefreshWxOpenToken(wxOpen *wxopen.WxOpen) {
+	for {
+		endTime := time.After(10 * time.Second)
+		<-endTime
+		token, err := wxOpen.RefreshAccessToken(0)
+		if err != nil {
+			fmt.Println("refresh wxopen token fail", err)
+		} else {
+			fmt.Printf("refresh token success '%s'\n", token)
+		}
+	}
+}
+
+func RefreshAuthorizerToken(authorizers []*authorizer.Authorizer) {
+	for {
+		endTime := time.After(10 * time.Second)
+		<-endTime
+		for _, auth := range authorizers {
+			token, err := auth.RefreshAccessToken(0)
+			if err != nil {
+				fmt.Printf(
+					"refresh authorizer(%s %s) fail, error %s",
+					auth.ComponentAppid, auth.Appid, err.Error(),
+				)
+			} else {
+				fmt.Printf(
+					"refresh authorizer(%s %s) token success '%s'\n",
+					auth.ComponentAppid, auth.Appid, token,
+				)
+			}
+		}
+	}
+}

--- a/examples/wxopen/wxopen_authorizer_token.go
+++ b/examples/wxopen/wxopen_authorizer_token.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/lixinio/weixin/weixin/authorizer"
 	"github.com/lixinio/weixin/wxopen"
@@ -27,7 +26,6 @@ func GetAuthorizerAccessToken(
 			return "", 0, err
 		}
 		tokenCache.SetRefreshToken(resp.RefreshToken) // noqa
-		fmt.Printf("refresh appid (%s) token (%s)\n", appid, resp.AccessToken)
 		return resp.AccessToken, resp.ExpiresIn, nil
 	}
 }

--- a/utils/cache.go
+++ b/utils/cache.go
@@ -12,4 +12,5 @@ type Cache interface {
 	Set(string, interface{}, time.Duration) error
 	IsExist(string) bool
 	Delete(string) error
+	TTL(string) (int, error)
 }

--- a/utils/redis/redis.go
+++ b/utils/redis/redis.go
@@ -3,6 +3,7 @@ package redis
 // https://github.com/silenceper/wechat/blob/master/cache/redis.go
 import (
 	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/gomodule/redigo/redis"
@@ -113,6 +114,25 @@ func (r *Redis) Delete(key string) error {
 	}
 
 	return nil
+}
+
+// 获得剩余时间(秒)
+func (r *Redis) TTL(key string) (int, error) {
+	conn := r.conn.Get()
+	defer conn.Close()
+
+	if reply, err := conn.Do("TTL", key); err != nil {
+		return -1, err
+	} else {
+		if ttl, ok := reply.(int64); ok {
+			// 如果不存在, 返回-2
+			return int(ttl), nil
+		} else {
+			return -1, fmt.Errorf(
+				"invalid ttl reply type '%s'", reflect.TypeOf(reply).String(),
+			)
+		}
+	}
 }
 
 // https://www.programmersought.com/article/85921351841/

--- a/utils/redis/redis_test.go
+++ b/utils/redis/redis_test.go
@@ -1,0 +1,43 @@
+package redis
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	key   = "key123"
+	value = "value456"
+	ttl   = 60
+)
+
+func TestRedis(t *testing.T) {
+	redis := NewRedis(&Config{RedisUrl: "redis://127.0.0.1:6379/1"})
+	err := redis.Set(key, value, time.Second*ttl)
+	require.Equal(t, err, nil)
+
+	var val string
+	exist, err := redis.Get(key, &val)
+	require.Equal(t, err, nil)
+	require.Equal(t, exist, true)
+	require.Equal(t, val, value)
+
+	ttl, err := redis.TTL(key)
+	require.Equal(t, err, nil)
+	fmt.Println("ttl", ttl)
+
+	err = redis.Delete(key)
+	require.Equal(t, err, nil)
+
+	exist, err = redis.Get(key, &val)
+	require.Equal(t, err, nil)
+	require.Equal(t, exist, false)
+
+	ttl, err = redis.TTL(key)
+	require.Equal(t, err, nil)
+	require.Less(t, ttl, 0)
+	fmt.Println("ttl", ttl)
+}

--- a/weixin/authorizer/authorizer_adapter.go
+++ b/weixin/authorizer/authorizer_adapter.go
@@ -1,0 +1,50 @@
+package authorizer
+
+import (
+	"fmt"
+
+	"github.com/lixinio/weixin/utils"
+)
+
+// 需要通过wxopen对象刷新authorizer Access token
+// https://developers.weixin.qq.com/doc/oplatform/Third-party_Platforms/2.0/api/ThirdParty/token/api_authorizer_token.html
+type RefreshAccessToken func() (string, int, error) // 直接获取token， 不做任何缓存
+
+// utils.AccessTokenGetter 接口实现
+type authorizerAccessTokenGetterAdapter struct {
+	accessTokenKey     string
+	accessTokenLockKey string
+	accessTokenGetter  RefreshAccessToken
+}
+
+// GetAccessToken 接口 utils.AccessTokenGetter 实现
+func (adapter *authorizerAccessTokenGetterAdapter) GetAccessToken() (string, int, error) {
+	return adapter.accessTokenGetter()
+}
+
+// GetAccessTokenKey 接口 utils.AccessTokenGetter 实现
+func (adapter *authorizerAccessTokenGetterAdapter) GetAccessTokenKey() string {
+	return adapter.accessTokenKey
+}
+
+// GetAccessTokenLockKey 接口 utils.AccessTokenGetter 实现
+func (adapter *authorizerAccessTokenGetterAdapter) GetAccessTokenLockKey() string {
+	return adapter.accessTokenLockKey
+}
+
+func newAdapter(
+	componentAppid, appid string,
+	accessTokenGetter RefreshAccessToken,
+) utils.AccessTokenGetter {
+	return &authorizerAccessTokenGetterAdapter{
+		accessTokenGetter: accessTokenGetter,
+		accessTokenKey: fmt.Sprintf(
+			"access-token:authorizer:%s:%s",
+			componentAppid, appid,
+		),
+		accessTokenLockKey: fmt.Sprintf(
+			"access-token:authorizer:%s:%s.lock",
+			componentAppid, appid,
+		),
+	}
+}

--- a/weixin/official_account/offiaccount.go
+++ b/weixin/official_account/offiaccount.go
@@ -29,7 +29,7 @@ func New(cache utils.Cache, locker utils.Lock, config *Config) *OfficialAccount 
 	}
 	instance.Client = utils.NewClient(
 		WXServerUrl,
-		utils.NewAccessTokenCache(instance, cache, locker, 0),
+		utils.NewAccessTokenCache(instance, cache, locker),
 	)
 	return instance
 }

--- a/wxopen/wxopen_adapter.go
+++ b/wxopen/wxopen_adapter.go
@@ -1,0 +1,104 @@
+package wxopen
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/lixinio/weixin/utils"
+)
+
+// ticket 缓存的adapter， 无法自行刷新，只能微信主动上报
+// https://developers.weixin.qq.com/doc/oplatform/Third-party_Platforms/2.0/api/ThirdParty/token/component_verify_ticket.html
+type ticketAdaptor struct {
+	tokenKey  string
+	lockerKey string
+}
+
+func (ta *ticketAdaptor) GetAccessToken() (accessToken string, expiresIn int, err error) {
+	return "", 0, errors.New("can NOT update wxopen ticket")
+}
+
+// GetAccessTokenKey 接口 weixin.AccessTokenGetter 实现
+func (ta *ticketAdaptor) GetAccessTokenKey() string {
+	return ta.tokenKey
+}
+
+// GetAccessTokenLockKey 接口 weixin.AccessTokenGetter 实现
+func (ta *ticketAdaptor) GetAccessTokenLockKey() string {
+	return ta.lockerKey
+}
+
+func newTicketAdapter(appid string) *ticketAdaptor {
+	return &ticketAdaptor{
+		tokenKey:  fmt.Sprintf("access-token:wxopen_ticket:%s", appid),
+		lockerKey: fmt.Sprintf("access-token:wxopen_ticket:%s.lock", appid),
+	}
+}
+
+// access token的cache
+type accessTokenAdaptor struct {
+	config      *Config
+	ticketCache *utils.AccessTokenCache
+	client      *utils.Client
+	tokenKey    string
+	lockerKey   string
+}
+
+// GetAccessTokenKey 接口 weixin.AccessTokenGetter 实现
+func (ta *accessTokenAdaptor) GetAccessTokenKey() string {
+	return ta.tokenKey
+}
+
+// GetAccessTokenLockKey 接口 weixin.AccessTokenGetter 实现
+func (ta *accessTokenAdaptor) GetAccessTokenLockKey() string {
+	return ta.lockerKey
+}
+
+func (ta *accessTokenAdaptor) GetAccessToken() (accessToken string, expiresIn int, err error) {
+	if ta.ticketCache == nil {
+		return "", 0, fmt.Errorf(
+			"wxopen appid : %s, error: %w", ta.config.Appid, ErrTokenUpdateForbidden,
+		)
+	}
+
+	ticket, err := ta.ticketCache.GetAccessToken()
+	if err != nil {
+		return "", 0, fmt.Errorf("can NOT get wxopen access token without ticket, %w", err)
+	}
+
+	// AccessToken 和其他地方 字段不一致
+	result := struct {
+		utils.WeixinError
+		AccessToken string `json:"component_access_token"`
+		ExpiresIn   int    `json:"expires_in"`
+	}{}
+
+	payload := map[string]string{
+		"component_appid":         ta.config.Appid,
+		"component_appsecret":     ta.config.Secret,
+		"component_verify_ticket": ticket,
+	}
+	if err := ta.client.HTTPPostToken(
+		context.TODO(), apiGetComponentToken, payload, &result,
+	); err != nil {
+		return "", 0, err
+	}
+	return result.AccessToken, result.ExpiresIn, nil
+}
+
+func newAccessTokenAdaptor(
+	config *Config,
+	ticketCache *utils.AccessTokenCache,
+) *accessTokenAdaptor {
+	adaptor := &accessTokenAdaptor{
+		config:      config,
+		ticketCache: ticketCache,
+		tokenKey:    fmt.Sprintf("access-token:wxopen:%s", config.Appid),
+		lockerKey:   fmt.Sprintf("access-token:wxopen:%s.lock", config.Appid),
+	}
+	if ticketCache != nil {
+		adaptor.client = utils.NewClient(WXServerUrl, utils.EmptyClientAccessTokenGetter(0))
+	}
+	return adaptor
+}

--- a/wxopen/wxopen_test.go
+++ b/wxopen/wxopen_test.go
@@ -2,7 +2,6 @@ package wxopen
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/lixinio/weixin/test"
@@ -27,9 +26,9 @@ func TestStartPushTicket(t *testing.T) {
 	require.Empty(t, err)
 }
 
-func TestRefreshToken(t *testing.T) {
-	open := initWxOpen()
-	token, _, err := open.refreshAccessTokenFromWXServer()
-	fmt.Println(token)
-	require.Empty(t, err)
-}
+// func TestRefreshToken(t *testing.T) {
+// 	open := initWxOpen()
+// 	token, _, err := open.refreshAccessTokenFromWXServer()
+// 	fmt.Println(token)
+// 	require.Empty(t, err)
+// }

--- a/wxwork/agent/agent.go
+++ b/wxwork/agent/agent.go
@@ -23,7 +23,7 @@ func New(corp *work.WxWork, cache utils.Cache, locker utils.Lock, config *Config
 		Config: config,
 		wxwork: corp,
 	}
-	instance.Client = corp.NewClient(utils.NewAccessTokenCache(instance, cache, locker, 0))
+	instance.Client = corp.NewClient(utils.NewAccessTokenCache(instance, cache, locker))
 	return instance
 }
 


### PR DESCRIPTION
+ 支持手动刷新Token (提前多少秒)
+ 写入token到缓存时, 减去30s, 避免获取Token到写入缓存成功的时间差导致失效的Token仍然停留在缓存
+ adapter和具体的微信对象分离(避免暴露一些无意义/让人误会的接口) 